### PR TITLE
Modify .gitignore to support PyCharm IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/


### PR DESCRIPTION
Added ".idea/" to .gitignore to prevent PyCharm project settings from being sent to the repository